### PR TITLE
Separate config file and compatibility with python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.txt

--- a/README.md
+++ b/README.md
@@ -7,6 +7,27 @@ This was designed specifically with Raspberry Pi servers in mind, but could be u
 
 Every time the script runs it will get the current domain config from gandi.net's API and look for the IP in the A record for the domain (default name for the record is '@' but you can change that if you want to).  It will then get your current external IP from a public "what is my ip" site.  Once it has both IPs it will compare what is in the DNS config vs what your IP is, and update the DNS config for the domain as appropriate so that it resolves to your current IP address.
 
+The configuration is stored in the script directory under the file `config.txt`. The syntax is the standard Python configuration file, and the format is the following:
+```
+[local]
+# gandi.net API (Production) key
+apikey = <CHANGE ME>
+# Domain
+domain = <CHANGE ME>
+# A-record name
+a_name = @
+# TTL (seconds = 5 mintes to 30 days)
+ttl = 900
+# Production API
+api = https://rpc.gandi.net/xmlrpc/
+# Host which IP should be changed
+host = localhost
+```
+
+- Do not forget to replace the values marked with `<CHANGE ME>` with your API key and domain.
+- You can have more than one config section (`[local]` above) if you need to update more than one domain/a_name.
+- `host` is either `localhost` in which case the script will fetch the current external address, or any other public name. Using an other ddns account will allow you to sync it with Gandi (useful when you are not running on the same IP than the one you want to update).
+
 Usage
 -----
 You will need to make sure that your domain is registered on gandi.net, and that you are using the gandi.net DNS servers (if you are using the default gandi.net zone for other domains you have on gandi.net, you might want to create a dedicated zone for the domain you will be using).  You'll also need to register for the API to get a key.  

--- a/gandi-ddns.py
+++ b/gandi-ddns.py
@@ -74,18 +74,20 @@ def change_zone_ip(new_ip):
   
   # Set new zone version as the active zone
   api.domain.zone.version.set(apikey, get_zone_id(), new_zone_ver)
-  
-zone_ip = get_zone_ip()
-current_ip = get_ip()
-
-if (zone_ip.strip() == current_ip.strip()):
-  sys.exit();
-else:
-  print 'DNS Mistmatch detected: A-record: ', zone_ip, ' WAN IP: ', current_ip
-  change_zone_ip(current_ip)
-  zone_id = None
-  zone_ip = get_zone_ip();
-  print 'DNS A record update complete - set to ', zone_ip
 
 
-	
+def main():
+  zone_ip = get_zone_ip()
+  current_ip = get_ip()
+
+  if (zone_ip.strip() == current_ip.strip()):
+    sys.exit();
+  else:
+    print 'DNS Mistmatch detected: A-record: ', zone_ip, ' WAN IP: ', current_ip
+    change_zone_ip(current_ip)
+    zone_id = None
+    zone_ip = get_zone_ip();
+    print 'DNS A record update complete - set to ', zone_ip
+
+if __name__ == "__main__":
+  main()

--- a/gandi-ddns.py
+++ b/gandi-ddns.py
@@ -2,52 +2,50 @@ from __future__ import print_function
 try:
   from xmlrpc import client as xmlrpclient
   from urllib.request import urlopen
+  import configparser
 except ImportError:
   from urllib2 import urlopen
   import xmlrpclib as xmlrpclient
+  import ConfigParser as configparser
 import sys
+import os
 
-# gandi.net API (Production) key
-apikey = '<CHANGE ME>'
-# Domain
-domain = '<CHANGE ME>'
-# A-record name
-a_name = '@'
-# TTL (seconds = 5 mintes to 30 days)
-ttl = 900
-# Production API
-api = xmlrpclient.ServerProxy('https://rpc.gandi.net/xmlrpc/', verbose=False)
 # Used to cache the zone_id for future calls
 zone_id = None
 
-def get_zone_id():
+config_file = "config.txt"
+
+def get_zone_id(config, section):
 	""" Get the gandi.net ID for the current zone version"""
-	
+
 	global zone_id
 	
 	# If we've not already got the zone ID, get it
 	if zone_id is None:
 		# Get domain info then check for a zone
-		domain_info = api.domain.info(apikey,domain)
+		domain_info = api.domain.info(config.get(section, "apikey"),
+                                  config.get(section, "domain"))
 		current_zone_id = domain_info['zone_id']
 
 		if current_zone_id == 'None':
 		  print('No zone - make sure domain is set to use gandi.net name servers.')
 		  sys.exit(1)
-		
+
 		zone_id = current_zone_id
 	
 	return zone_id
 
-def get_zone_ip():
+def get_zone_ip(config, section):
 	"""Get the current IP from the A record in the DNS zone """
 
-	current_zone = api.domain.zone.record.list(apikey, get_zone_id(), 0)
+	current_zone = api.domain.zone.record.list(config.get(section, "apikey"),
+                                             get_zone_id(config, section),
+                                             0)
 	ip = '0.0.0.0'
 	# There may be more than one A record - we're interested in one with 
 	# the specific name (typically @ but could be sub domain)
 	for d in current_zone:
-	  if d['type'] == 'A'and d['name'] == a_name:
+	  if d['type'] == 'A'and d['name'] == config.get(section, "a_name"):
 	    ip = d['value']
 	  
 	return ip
@@ -64,34 +62,67 @@ def get_ip():
 	
 	return result.decode()
 
-def change_zone_ip(new_ip):
+def change_zone_ip(config, section, new_ip):
   """ Change the zone record to the new IP """
+  a_name = config.get(section, "a_name")
+  apikey = config.get(section, "apikey")
+  ttl = int(config.get(section, "ttl"))
+  zone_id = get_zone_id(config, section)
   
   zone_record ={'name': a_name, 'value': new_ip, 'ttl':ttl, 'type': 'A'}
   
-  new_zone_ver = api.domain.zone.version.new(apikey, get_zone_id())
+  new_zone_ver = api.domain.zone.version.new(apikey, zone_id)
   
   # clear old A record (defaults to previous verison's
-  api.domain.zone.record.delete(apikey, get_zone_id(), new_zone_ver,{'type':'A', 'name': a_name})
+  api.domain.zone.record.delete(apikey, zone_id, new_zone_ver, {'type':'A', 'name': a_name})
   
   # Add in new A record
-  api.domain.zone.record.add(apikey, get_zone_id(), new_zone_ver, zone_record)
+  api.domain.zone.record.add(apikey, zone_id, new_zone_ver, zone_record)
   
   # Set new zone version as the active zone
-  api.domain.zone.version.set(apikey, get_zone_id(), new_zone_ver)
+  api.domain.zone.version.set(apikey, zone_id, new_zone_ver)
 
+def read_config(config_path):
+  """ Open the configuration file or create it if it doesn't exists """
+  if not os.path.exists(config_path):
+    with open(config_path, "w") as f:
+      f.write("""[local]
+# gandi.net API (Production) key
+apikey = <CHANGE ME>
+# Domain
+domain = <CHANGE ME>
+# A-record name
+a_name = @
+# TTL (seconds = 5 mintes to 30 days)
+ttl = 900
+# Production API
+api = https://rpc.gandi.net/xmlrpc/
+""")
+    return None
+  cfg = configparser.ConfigParser()
+  cfg.read(config_path)
+  return cfg
 
 def main():
-  zone_ip = get_zone_ip()
+  global api, zone_id
+  config = read_config(config_file)
+  if not config:
+    sys.exit("please fill in the 'config.txt' file")
+
+  section = config.sections()[0]
+
+  api = xmlrpclient.ServerProxy(config.get(section, "api"), verbose=False)
+
+  zone_ip = get_zone_ip(config, section).strip()
   current_ip = get_ip()
 
   if (zone_ip.strip() == current_ip.strip()):
     sys.exit();
   else:
     print('DNS Mistmatch detected: A-record: ', zone_ip, ' WAN IP: ', current_ip)
-    change_zone_ip(current_ip)
+    change_zone_ip(config, section, current_ip)
     zone_id = None
-    zone_ip = get_zone_ip();
+    zone_ip = get_zone_ip(config, section);
     print('DNS A record update complete - set to ', zone_ip)
 
 if __name__ == "__main__":

--- a/gandi-ddns.py
+++ b/gandi-ddns.py
@@ -13,7 +13,12 @@ import os
 # Used to cache the zone_id for future calls
 zone_id = None
 
+# name of the configuration file.
+# If the full path is not given, gandi-ddns.py will check for this file in
+# its current directory
 config_file = "config.txt"
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 def get_zone_id(config, section):
 	""" Get the gandi.net ID for the current zone version"""
@@ -105,7 +110,10 @@ api = https://rpc.gandi.net/xmlrpc/
 
 def main():
   global api, zone_id
-  config = read_config(config_file)
+  path = config_file
+  if not path.startswith('/'):
+    path = os.path.join(SCRIPT_DIR, path)
+  config = read_config(path)
   if not config:
     sys.exit("please fill in the 'config.txt' file")
 

--- a/gandi-ddns.py
+++ b/gandi-ddns.py
@@ -117,21 +117,20 @@ def main():
   if not config:
     sys.exit("please fill in the 'config.txt' file")
 
-  section = config.sections()[0]
+  for section in config.sections():
+    api = xmlrpclient.ServerProxy(config.get(section, "api"), verbose=False)
 
-  api = xmlrpclient.ServerProxy(config.get(section, "api"), verbose=False)
+    zone_ip = get_zone_ip(config, section).strip()
+    current_ip = get_ip()
 
-  zone_ip = get_zone_ip(config, section).strip()
-  current_ip = get_ip()
-
-  if (zone_ip.strip() == current_ip.strip()):
-    sys.exit();
-  else:
-    print('DNS Mistmatch detected: A-record: ', zone_ip, ' WAN IP: ', current_ip)
-    change_zone_ip(config, section, current_ip)
-    zone_id = None
-    zone_ip = get_zone_ip(config, section);
-    print('DNS A record update complete - set to ', zone_ip)
+    if (zone_ip.strip() == current_ip.strip()):
+      sys.exit();
+    else:
+      print('DNS Mistmatch detected: A-record: ', zone_ip, ' WAN IP: ', current_ip)
+      change_zone_ip(config, section, current_ip)
+      zone_id = None
+      zone_ip = get_zone_ip(config, section);
+      print('DNS A record update complete - set to ', zone_ip)
 
 if __name__ == "__main__":
   main()

--- a/gandi-ddns.py
+++ b/gandi-ddns.py
@@ -1,5 +1,10 @@
-import xmlrpclib
-import urllib2
+from __future__ import print_function
+try:
+  from xmlrpc import client as xmlrpclient
+  from urllib.request import urlopen
+except ImportError:
+  from urllib2 import urlopen
+  import xmlrpclib as xmlrpclient
 import sys
 
 # gandi.net API (Production) key
@@ -11,7 +16,7 @@ a_name = '@'
 # TTL (seconds = 5 mintes to 30 days)
 ttl = 900
 # Production API
-api = xmlrpclib.ServerProxy('https://rpc.gandi.net/xmlrpc/', verbose=False)
+api = xmlrpclient.ServerProxy('https://rpc.gandi.net/xmlrpc/', verbose=False)
 # Used to cache the zone_id for future calls
 zone_id = None
 
@@ -27,7 +32,7 @@ def get_zone_id():
 		current_zone_id = domain_info['zone_id']
 
 		if current_zone_id == 'None':
-		  print 'No zone - make sure domain is set to use gandi.net name servers.'
+		  print('No zone - make sure domain is set to use gandi.net name servers.')
 		  sys.exit(1)
 		
 		zone_id = current_zone_id
@@ -52,12 +57,12 @@ def get_ip():
 	
 	try:
 	  # Could be any service that just gives us a simple raw ASCII IP address (not HTML etc)
-	  result = urllib2.urlopen("http://ipv4.myexternalip.com/raw", timeout=3).read()
+	  result = urlopen("http://ipv4.myexternalip.com/raw", timeout=3).read()
 	except Exception:
-	  print 'Unable to external IP address.'
+	  print('Unable to external IP address.')
 	  sys.exit(2);
 	
-	return result
+	return result.decode()
 
 def change_zone_ip(new_ip):
   """ Change the zone record to the new IP """
@@ -83,11 +88,11 @@ def main():
   if (zone_ip.strip() == current_ip.strip()):
     sys.exit();
   else:
-    print 'DNS Mistmatch detected: A-record: ', zone_ip, ' WAN IP: ', current_ip
+    print('DNS Mistmatch detected: A-record: ', zone_ip, ' WAN IP: ', current_ip)
     change_zone_ip(current_ip)
     zone_id = None
     zone_ip = get_zone_ip();
-    print 'DNS A record update complete - set to ', zone_ip
+    print('DNS A record update complete - set to ', zone_ip)
 
 if __name__ == "__main__":
   main()

--- a/gandi-ddns.py
+++ b/gandi-ddns.py
@@ -9,6 +9,7 @@ except ImportError:
   import ConfigParser as configparser
 import sys
 import os
+import socket
 
 # Used to cache the zone_id for future calls
 zone_id = None
@@ -102,6 +103,8 @@ a_name = @
 ttl = 900
 # Production API
 api = https://rpc.gandi.net/xmlrpc/
+# Host which IP should be changed
+host = localhost
 """)
     return None
   cfg = configparser.ConfigParser()
@@ -121,7 +124,9 @@ def main():
     api = xmlrpclient.ServerProxy(config.get(section, "api"), verbose=False)
 
     zone_ip = get_zone_ip(config, section).strip()
-    current_ip = get_ip()
+    current_ip = socket.gethostbyname(config.get(section, "host"))
+    if current_ip == '127.0.0.1':
+      current_ip = get_ip()
 
     if (zone_ip.strip() == current_ip.strip()):
       sys.exit();


### PR DESCRIPTION
Hi,

For my own needs, I had to enhance a little your great script.

This pull request adds several features to gandi-ddns:
- python 3 compatibility (in the tests I run, both python 2 and python 3 were working correctly)
- usage of an external file to not put private credentials in the git history by mistake
- allow to have more than one field updated by launch
- allow to run the file from a different IP than the A name we update (but we need to use a different ddns account for this)

Cheers,
Benjamin
