### PR TITLE
Don't always return None when reading config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ api = https://rpc.gandi.net/xmlrpc/
 host = localhost
 ```
 
-- Do not forget to replace the values marked with `<CHANGE ME>` with your API key and domain.
+- Do not forget to replace the values marked with `<CHANGE ME>` with your 24-character API key and domain.
 - You can have more than one config section (`[local]` above) if you need to update more than one domain/a_name.
 - `host` is either `localhost` in which case the script will fetch the current external address, or any other public name. Using an other ddns account will allow you to sync it with Gandi (useful when you are not running on the same IP than the one you want to update).
 

--- a/gandi-ddns.py
+++ b/gandi-ddns.py
@@ -97,24 +97,27 @@ def change_zone_ip(config, section, new_ip):
     api.domain.zone.version.set(apikey, zone_id, new_zone_ver)
 
 
+default_config = """[local]
+# gandi.net API (Production) key
+apikey = <CHANGE ME>
+# Domain
+domain = <CHANGE ME>
+# A-record name
+a_name = @
+# TTL (seconds = 5 mintes to 30 days)
+ttl = 900
+# Production API
+api = https://rpc.gandi.net/xmlrpc/
+# Host which IP should be changed
+host = localhost
+"""
+
+
 def read_config(config_path):
     """ Open the configuration file or create it if it doesn't exists """
     if not os.path.exists(config_path):
         with open(config_path, "w") as f:
-            f.write("""[local]
-                    # gandi.net API (Production) key
-                    apikey = <CHANGE ME>
-                    # Domain
-                    domain = <CHANGE ME>
-                    # A-record name
-                    a_name = @
-                    # TTL (seconds = 5 mintes to 30 days)
-                    ttl = 900
-                    # Production API
-                    api = https://rpc.gandi.net/xmlrpc/
-                    # Host which IP should be changed
-                    host = localhost
-                    """)
+            f.write(default_config)
         return None
     cfg = configparser.ConfigParser()
     cfg.read(config_path)
@@ -131,8 +134,7 @@ def main():
         sys.exit("please fill in the 'config.txt' file")
 
     for section in config.sections():
-        api = xmlrpclient.ServerProxy(config.get(section,
-                                                 "api"), verbose=False)
+        api = xmlrpclient.ServerProxy(config.get(section, "api"), verbose=False)
 
         zone_ip = get_zone_ip(config, section).strip()
         current_ip = socket.gethostbyname(config.get(section, "host"))

--- a/gandi-ddns.py
+++ b/gandi-ddns.py
@@ -115,7 +115,7 @@ def read_config(config_path):
                     # Host which IP should be changed
                     host = localhost
                     """)
-    return None
+        return None
     cfg = configparser.ConfigParser()
     cfg.read(config_path)
     return cfg


### PR DESCRIPTION
Hey! I discovered what looks to me like a bug when reading and creating the blank configuration file always executing `return None` even when a file exists.

Full disclosure: I noticed it while debugging this for a colleague, and I haven't tested that this script as a whole works. Do please feel free to decline it if this isn't useful (or, obviously, is just plain wrong).